### PR TITLE
feat: discount support

### DIFF
--- a/.github/workflows/slither.yml
+++ b/.github/workflows/slither.yml
@@ -3,6 +3,8 @@ on: [push]
 jobs:
   analyze:
     runs-on: ubuntu-latest
+    permissions:
+      security-events: write
     steps:
       - uses: actions/checkout@v3
 

--- a/contracts/PartnerConfiguration/IPartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/IPartnerConfiguration.sol
@@ -122,14 +122,16 @@ interface IPartnerConfiguration {
     /**
      * @notice sets the discount assigned to the partner for each domain name registered
      * @param discount the discount assigned to the partner for each domain name registered
-     * @custom:emits-event emits the DiscountChanged event on success
+     * @custom:emits-event emits the DiscountChanged event on success. N.B: percentage value
+     * should be multiplied with the precision value of 10^18, i.e percentageValue * 10^18
      */
     function setDiscount(uint256 discount) external;
 
     /**
      * @notice sets the fee percentage assigned to the partner for each domain name registered
      * @param feePercentage the percentage assigned to the partner for each domain name registered
-     * @custom:emits-event emits the FeePercentageChanged event on success
+     * @custom:emits-event emits the FeePercentageChanged event on success. N.B: percentage value
+     * should be multiplied with the precision value of 10^18, i.e percentageValue * 10^18
      */
     function setFeePercentage(uint256 feePercentage) external;
 

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -349,6 +349,9 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
     }
 
     function _applyDiscount(uint256 price) private view returns (uint256) {
+        // 100% discount applied
+        if (_discount == _PERCENT100_WITH_PRECISION18) return 0;
+        
         uint256 discounted_price = (price * _discount) /
             _PERCENT100_WITH_PRECISION18;
         uint256 final_price = price - discounted_price;

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -304,6 +304,7 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
     ) external view override returns (uint256) {
         uint256 actualPrice;
 
+        // 100% discount applied
         if (_discount == _PERCENT100_WITH_PRECISION18) return 0;
 
         if (duration == 1) {

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -24,6 +24,7 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
     uint256 private _minCommitmentAge;
 
     uint256 internal constant _PERCENT100_WITH_PRECISION18 = 100 * (10 ** 18);
+    uint256 internal constant _PRECISION18 = 10 ** 18;
     string internal constant _UN_NECESSARY_MODIFICATION_ERROR_MSG =
         "Param being modified is same as new param";
     string internal constant _VALUE_OUT_OF_BOUND_ERROR_MSG =
@@ -308,15 +309,15 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
         if (_discount == _PERCENT100_WITH_PRECISION18) return 0;
 
         if (duration == 1) {
-            actualPrice = 2 * (10 ** 18);
+            actualPrice = 2 * (_PRECISION18);
             return _applyDiscount(actualPrice);
         }
         if (duration == 2) {
-            actualPrice = 4 * (10 ** 18);
+            actualPrice = 4 * (_PRECISION18);
             return _applyDiscount(actualPrice);
         }
 
-        actualPrice = (duration + 2) * (10 ** 18);
+        actualPrice = (duration + 2) * (_PRECISION18);
 
         return _applyDiscount(actualPrice);
     }

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -264,7 +264,7 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
         emit DiscountChanged(preModifiedValue, discount);
 
         if (preModifiedValue == discount) {
-            revert("Param being modified is same as new param");
+            revert(_UN_NECESSARY_MODIFICATION_ERROR_MSG);
         }
 
         if (discount > _PERCENT100_WITH_PRECISION18) {

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -355,10 +355,10 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
         // No discount to be applied
         if (_discount == 0) return price;
 
-        uint256 discounted_price = (price * _discount) /
+        uint256 discountedPrice = (price * _discount) /
             _PERCENT100_WITH_PRECISION18;
-        uint256 final_price = price - discounted_price;
+        uint256 finalPrice = price - discountedPrice;
 
-        return final_price;
+        return finalPrice;
     }
 }

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -234,6 +234,10 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
             revert("Param being modified is same as new param");
         }
 
+        if (feePercentage > 100) {
+            revert("Value must be within range 0 to 100");
+        }
+
         _feePercentage = feePercentage;
     }
 
@@ -254,6 +258,10 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
 
         if (preModifiedValue == discount) {
             revert("Param being modified is same as new param");
+        }
+
+        if (discount > 100) {
+            revert("Value must be within range 0 to 100");
         }
 
         _discount = discount;

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -308,15 +308,13 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
         // 100% discount applied
         if (_discount == _PERCENT100_WITH_PRECISION18) return 0;
 
-        if (duration == 1) {
-            actualPrice = 2 * (_PRECISION18);
-            return _applyDiscount(actualPrice);
-        }
-        if (duration == 2) {
-            actualPrice = 4 * (_PRECISION18);
+        // for duration equal to 1 or 2
+        if (duration <= 2) {
+            actualPrice = (2 * duration) * _PRECISION18;
             return _applyDiscount(actualPrice);
         }
 
+        // for duration greater than 2
         actualPrice = (duration + 2) * (_PRECISION18);
 
         return _applyDiscount(actualPrice);

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -351,7 +351,7 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
     function _applyDiscount(uint256 price) private view returns (uint256) {
         // 100% discount applied
         if (_discount == _PERCENT100_WITH_PRECISION18) return 0;
-        
+
         uint256 discounted_price = (price * _discount) /
             _PERCENT100_WITH_PRECISION18;
         uint256 final_price = price - discounted_price;

--- a/contracts/PartnerConfiguration/PartnerConfiguration.sol
+++ b/contracts/PartnerConfiguration/PartnerConfiguration.sol
@@ -352,6 +352,9 @@ contract PartnerConfiguration is IPartnerConfiguration, Ownable {
         // 100% discount applied
         if (_discount == _PERCENT100_WITH_PRECISION18) return 0;
 
+        // No discount to be applied
+        if (_discount == 0) return price;
+
         uint256 discounted_price = (price * _discount) /
             _PERCENT100_WITH_PRECISION18;
         uint256 final_price = price - discounted_price;

--- a/contracts/Registrar/PartnerRegistrar.sol
+++ b/contracts/Registrar/PartnerRegistrar.sol
@@ -134,13 +134,22 @@ contract PartnerRegistrar is IBaseRegistrar, Ownable, IERC677TransferReceiver {
             addr,
             partner
         );
-        require(amount >= cost, "Insufficient tokens transferred");
 
-        _collectFees(partner, cost);
+        // This aims to skip token transfer transactions if the cost is zero as it doesn't make
+        // any sense to have transactions involving zero tokens. Hence calculations are
+        // only done for non zero cost domain registrations.
+        if (cost > 0) {
+            require(amount >= cost, "Insufficient tokens transferred");
 
-        uint256 difference = amount - cost;
-        if (difference > 0)
-            require(_rif.transfer(from, difference), "Token transfer failed");
+            _collectFees(partner, cost);
+
+            uint256 difference = amount - cost;
+            if (difference > 0)
+                require(
+                    _rif.transfer(from, difference),
+                    "Token transfer failed"
+                );
+        }
     }
 
     function _collectFees(address partner, uint256 amount) private {
@@ -183,12 +192,17 @@ contract PartnerRegistrar is IBaseRegistrar, Ownable, IERC677TransferReceiver {
             partner
         );
 
-        require(
-            _rif.transferFrom(msg.sender, address(this), cost),
-            "Token transfer failed"
-        );
+        // This aims to skip token transfer transactions if the cost is zero as it doesn't make
+        // any sense to have transactions involving zero tokens. Hence calculations are
+        // only done for non zero cost domain registrations.
+        if (cost > 0) {
+            require(
+                _rif.transferFrom(msg.sender, address(this), cost),
+                "Token transfer failed"
+            );
 
-        _collectFees(partner, cost);
+            _collectFees(partner, cost);
+        }
     }
 
     /**

--- a/test/FeeManager.spec.ts
+++ b/test/FeeManager.spec.ts
@@ -18,7 +18,6 @@ import { FakeContract, MockContract } from '@defi-wonderland/smock';
 import {
   DEPOSIT_SUCCESSFUL_EVENT,
   WITHDRAWAL_SUCCESSFUL_EVENT,
-  UN_NECESSARY_MODIFICATION_ERROR_MSG,
 } from './utils/constants.utils';
 
 async function testSetup() {
@@ -49,8 +48,6 @@ async function testSetup() {
     PartnerManager.address,
     pool.address,
   ]);
-
-  const oneRBTC = ethers.BigNumber.from(10).pow(18);
 
   return {
     RIF,

--- a/test/PartnerConfiguration.spec.ts
+++ b/test/PartnerConfiguration.spec.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_DISCOUNT,
   DEFAULT_IS_UNICODE_SUPPORTED,
   DEFAULT_FEE_PERCENTAGE,
+  VALUE_OUT_OF_PERCENT_RANGE_ERROR_MSG,
 } from './utils/constants.utils';
 
 const initialSetup = async () => {
@@ -461,6 +462,20 @@ describe('Partner Configuration', () => {
       await expect(
         PartnerConfiguration.setMinCommitmentAge(DEFAULT_MIN_COMMITMENT_AGE)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
+    });
+
+    it('Should revert if value being set is outside of allowed range for the discount', async () => {
+      const OUT_OF_RANGE_DISCOUNT = DEFAULT_DISCOUNT + 100;
+      await expect(
+        PartnerConfiguration.setDiscount(OUT_OF_RANGE_DISCOUNT)
+      ).to.be.revertedWith(VALUE_OUT_OF_PERCENT_RANGE_ERROR_MSG);
+    });
+
+    it.only('Should revert if value being set is outside of allowed range for the fee percentage', async () => {
+      const OUT_OF_RANGE_FEE_PERCENTAGE = DEFAULT_FEE_PERCENTAGE + 100;
+      await expect(
+        PartnerConfiguration.setFeePercentage(OUT_OF_RANGE_FEE_PERCENTAGE)
+      ).to.be.revertedWith(VALUE_OUT_OF_PERCENT_RANGE_ERROR_MSG);
     });
   });
 });

--- a/test/PartnerConfiguration.spec.ts
+++ b/test/PartnerConfiguration.spec.ts
@@ -56,15 +56,10 @@ const initialSetup = async () => {
 };
 
 describe('Partner Configuration', () => {
-  let PartnerConfiguration: MockContract<PartnerConfiguration>;
-  beforeEach(async () => {
-    const vars = await loadFixture(initialSetup);
-
-    PartnerConfiguration = vars.PartnerConfiguration;
-  });
-
-  context('when the contract is deployed', () => {
+  describe('when the contract is deployed', () => {
     it('should revert if the min length is 0', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
+
       await expect(
         deployContract<PartnerConfiguration__factory>('PartnerConfiguration', [
           0,
@@ -80,6 +75,7 @@ describe('Partner Configuration', () => {
     });
 
     it('should revert if the max length is less than the min length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         deployContract<PartnerConfiguration__factory>('PartnerConfiguration', [
           DEFAULT_MIN_LENGTH,
@@ -95,6 +91,7 @@ describe('Partner Configuration', () => {
     });
 
     it('should revert if the min duration is 0', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         deployContract<PartnerConfiguration__factory>('PartnerConfiguration', [
           DEFAULT_MIN_LENGTH,
@@ -110,6 +107,7 @@ describe('Partner Configuration', () => {
     });
 
     it('should revert if the max duration is less than the min duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         deployContract<PartnerConfiguration__factory>('PartnerConfiguration', [
           DEFAULT_MIN_LENGTH,
@@ -125,55 +123,62 @@ describe('Partner Configuration', () => {
     });
   });
 
-  context('Check Defaults', () => {
+  describe('Check Defaults', () => {
     it('Should return the default min length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getMinLength()).to.equal(
         DEFAULT_MIN_LENGTH
       );
     });
     it('Should return the default max length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getMaxLength()).to.equal(
         DEFAULT_MAX_LENGTH
       );
     });
     it('Should return the default flag for unicode support', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getUnicodeSupport()).to.equal(
         DEFAULT_IS_UNICODE_SUPPORTED
       );
     });
     it('Should return the default min duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getMinDuration()).to.equal(
         DEFAULT_MIN_DURATION
       );
     });
     it('Should return the default max duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getMaxDuration()).to.equal(
         DEFAULT_MAX_DURATION
       );
     });
     it('Should return the default fee percentage', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getFeePercentage()).to.equal(
         DEFAULT_FEE_PERCENTAGE
       );
     });
     it('Should return the default discount', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getDiscount()).to.equal(
         DEFAULT_DISCOUNT
       );
     });
     it('Should return the default commitment age', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       expect(await PartnerConfiguration.getMinCommitmentAge()).to.equal(
         DEFAULT_MIN_COMMITMENT_AGE
       );
     });
   });
 
-  context('getPrice', () => {
+  describe('getPrice', () => {
     it('Should return the correct price', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const expires = BigNumber.from(1);
       const name = 'cheta';
-
-      await PartnerConfiguration.setMaxDuration(BigNumber.from(7));
 
       let duration = BigNumber.from(2);
       expect(
@@ -195,9 +200,27 @@ describe('Partner Configuration', () => {
         await PartnerConfiguration.getPrice(name, expires, duration)
       ).to.be.equal(oneRBTC.mul(BigNumber.from(2).add(duration)));
     });
+
+    it('Should return price as zero when discount is 100%', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
+      const expires = BigNumber.from(1);
+      const name = 'cheta';
+
+      console.log(oneRBTC.mul(100));
+      (await PartnerConfiguration.setDiscount(oneRBTC.mul(100))).wait();
+
+      const duration = BigNumber.from(1);
+      const price = await PartnerConfiguration.getPrice(
+        name,
+        expires,
+        duration
+      );
+      expect(price).to.be.equal(ethers.constants.Zero);
+    });
   });
-  context('validateName', () => {
+  describe('validateName', () => {
     it('Should revert if duration is less than min duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const duration = BigNumber.from(1);
       const name = 'cheta';
 
@@ -209,6 +232,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should revert if duration is more than max duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const duration = BigNumber.from(6);
       const name = 'cheta';
 
@@ -220,6 +244,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should revert if length is less than min length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const duration = BigNumber.from(2);
       const name = 'cheta';
 
@@ -231,6 +256,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should revert if length is more than max length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const duration = BigNumber.from(2);
       const name = 'cheta';
 
@@ -242,6 +268,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should check if the name is valid', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const duration = BigNumber.from(2);
       const name = 'cheta';
 
@@ -250,20 +277,23 @@ describe('Partner Configuration', () => {
     });
   });
 
-  context('Set New Config Values', () => {
+  describe('Set New Config Values', () => {
     it('Should revert if min length is 0', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_LENGTH = 0;
       await expect(
         PartnerConfiguration.setMinLength(NEW_MIN_LENGTH)
       ).to.be.revertedWithCustomError(PartnerConfiguration, 'InvalidLength');
     });
     it('Should revert if min length is more than max length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_LENGTH = DEFAULT_MAX_LENGTH + 1;
       await expect(
         PartnerConfiguration.setMinLength(NEW_MIN_LENGTH)
       ).to.be.revertedWithCustomError(PartnerConfiguration, 'InvalidLength');
     });
     it('Should revert if max length is less than min length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_LENGTH = 4;
       await PartnerConfiguration.setMinLength(NEW_MIN_LENGTH);
 
@@ -272,18 +302,21 @@ describe('Partner Configuration', () => {
       ).to.be.revertedWithCustomError(PartnerConfiguration, 'InvalidLength');
     });
     it('Should revert if min duration is 0', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_DURATION = 0;
       await expect(
         PartnerConfiguration.setMinDuration(NEW_MIN_DURATION)
       ).to.be.revertedWithCustomError(PartnerConfiguration, 'InvalidDuration');
     });
     it('Should revert if min duration more than max duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_DURATION = DEFAULT_MAX_DURATION + 1;
       await expect(
         PartnerConfiguration.setMinDuration(NEW_MIN_DURATION)
       ).to.be.revertedWithCustomError(PartnerConfiguration, 'InvalidDuration');
     });
     it('Should revert if max duration is less than min duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await PartnerConfiguration.setMinDuration(DEFAULT_MAX_DURATION);
 
       await expect(
@@ -291,6 +324,7 @@ describe('Partner Configuration', () => {
       ).to.be.revertedWithCustomError(PartnerConfiguration, 'InvalidDuration');
     });
     it('Should set a new min length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_LENGTH = 4;
       const tx = await PartnerConfiguration.setMinLength(NEW_MIN_LENGTH);
       tx.wait();
@@ -299,6 +333,7 @@ describe('Partner Configuration', () => {
       );
     });
     it('Should set a new max length', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MAX_LENGTH = 8;
       const tx = await PartnerConfiguration.setMaxLength(NEW_MAX_LENGTH);
       tx.wait();
@@ -307,11 +342,13 @@ describe('Partner Configuration', () => {
       );
     });
     it('Should set a new flag for unicode support', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const tx = await PartnerConfiguration.setUnicodeSupport(true);
       tx.wait();
       expect(await PartnerConfiguration.getUnicodeSupport()).to.be.true;
     });
     it('Should set a new min duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_DURATION = 2;
       const tx = await PartnerConfiguration.setMinDuration(NEW_MIN_DURATION);
       tx.wait();
@@ -320,6 +357,7 @@ describe('Partner Configuration', () => {
       );
     });
     it('Should set a new max duration', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MAX_DURATION = 3;
       const tx = await PartnerConfiguration.setMaxDuration(NEW_MAX_DURATION);
       tx.wait();
@@ -328,6 +366,7 @@ describe('Partner Configuration', () => {
       );
     });
     it('Should set a new fee percentage', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_FEE_PERCENTAGE = 2;
       const tx = await PartnerConfiguration.setFeePercentage(
         NEW_FEE_PERCENTAGE
@@ -338,12 +377,14 @@ describe('Partner Configuration', () => {
       );
     });
     it('Should set a new discount', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_DISCOUNT = 3;
       const tx = await PartnerConfiguration.setDiscount(NEW_DISCOUNT);
       tx.wait();
       expect(await PartnerConfiguration.getDiscount()).to.equal(NEW_DISCOUNT);
     });
     it('Should return the default commitment age', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_COMMITMENT_AGE = 6;
       const tx = await PartnerConfiguration.setMinCommitmentAge(
         NEW_MIN_COMMITMENT_AGE
@@ -355,14 +396,16 @@ describe('Partner Configuration', () => {
     });
   });
 
-  context('Config modification events', () => {
+  describe('Config modification events', () => {
     it('Should emit the MinDurationChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_DURATION = DEFAULT_MIN_DURATION + 1;
       await expect(PartnerConfiguration.setMinDuration(NEW_MIN_DURATION))
         .to.emit(PartnerConfiguration, MIN_DURATION_CHANGED_EVENT)
         .withArgs(DEFAULT_MIN_DURATION, NEW_MIN_DURATION);
     });
     it('Should emit the MaxDurationChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MAX_DURATION = DEFAULT_MAX_DURATION + 1;
       await expect(PartnerConfiguration.setMaxDuration(NEW_MAX_DURATION))
         .to.emit(PartnerConfiguration, MAX_DURATION_CHANGED_EVENT)
@@ -370,6 +413,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should emit the UnicodeSupportChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_IS_UNICODE_SUPPORTED = !DEFAULT_IS_UNICODE_SUPPORTED;
       await expect(
         PartnerConfiguration.setUnicodeSupport(NEW_IS_UNICODE_SUPPORTED)
@@ -379,6 +423,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should emit the MinLengthChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_LENGTH = DEFAULT_MIN_LENGTH + 1;
       await expect(PartnerConfiguration.setMinLength(NEW_MIN_LENGTH))
         .to.emit(PartnerConfiguration, MIN_LENGTH_CHANGED_EVENT)
@@ -386,6 +431,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should emit the MaxLengthChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MAX_LENGTH = DEFAULT_MAX_LENGTH + 1;
       await expect(PartnerConfiguration.setMaxLength(NEW_MAX_LENGTH))
         .to.emit(PartnerConfiguration, MAX_LENGTH_CHANGED_EVENT)
@@ -393,6 +439,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should emit the FeePercentageChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_FEE_PERCENTAGE = DEFAULT_FEE_PERCENTAGE + 1;
       await expect(PartnerConfiguration.setFeePercentage(NEW_FEE_PERCENTAGE))
         .to.emit(PartnerConfiguration, FEE_PERCENTAGE_CHANGED_EVENT)
@@ -400,6 +447,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should emit the DiscountChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_DISCOUNT = DEFAULT_DISCOUNT + 1;
       await expect(PartnerConfiguration.setDiscount(NEW_DISCOUNT))
         .to.emit(PartnerConfiguration, DISCOUNT_CHANGED_EVENT)
@@ -407,6 +455,7 @@ describe('Partner Configuration', () => {
     });
 
     it('Should emit the MinCommitmentAgeChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       const NEW_MIN_COMMITMENT_AGE = DEFAULT_MIN_COMMITMENT_AGE + 1;
       await expect(
         PartnerConfiguration.setMinCommitmentAge(NEW_MIN_COMMITMENT_AGE)
@@ -416,63 +465,73 @@ describe('Partner Configuration', () => {
     });
   });
 
-  context('Config checks', () => {
+  describe('Config checks', () => {
     it('Should emit the MinDurationChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setMinDuration(DEFAULT_MIN_DURATION)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
     it('Should emit the MaxDurationChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setMaxDuration(DEFAULT_MAX_DURATION)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
 
     it('Should emit the UnicodeSupportChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setUnicodeSupport(DEFAULT_IS_UNICODE_SUPPORTED)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
 
     it('Should emit the MinLengthChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setMinLength(DEFAULT_MIN_LENGTH)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
 
     it('Should emit the MaxLengthChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setMaxLength(DEFAULT_MAX_LENGTH)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
 
     it('Should emit the FeePercentageChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setFeePercentage(DEFAULT_FEE_PERCENTAGE)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
 
     it('Should emit the DiscountChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setDiscount(DEFAULT_DISCOUNT)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
 
     it('Should emit the MinCommitmentAgeChanged event with the correct params', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
       await expect(
         PartnerConfiguration.setMinCommitmentAge(DEFAULT_MIN_COMMITMENT_AGE)
       ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
     });
 
     it('Should revert if value being set is outside of allowed range for the discount', async () => {
-      const OUT_OF_RANGE_DISCOUNT = DEFAULT_DISCOUNT + 100;
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
+      const OUT_OF_RANGE_DISCOUNT = oneRBTC.mul(101);
       await expect(
         PartnerConfiguration.setDiscount(OUT_OF_RANGE_DISCOUNT)
       ).to.be.revertedWith(VALUE_OUT_OF_PERCENT_RANGE_ERROR_MSG);
     });
 
-    it.only('Should revert if value being set is outside of allowed range for the fee percentage', async () => {
-      const OUT_OF_RANGE_FEE_PERCENTAGE = DEFAULT_FEE_PERCENTAGE + 100;
+    it('Should revert if value being set is outside of allowed range for the fee percentage', async () => {
+      const { PartnerConfiguration } = await loadFixture(initialSetup);
+      const OUT_OF_RANGE_FEE_PERCENTAGE = oneRBTC.mul(101);
       await expect(
         PartnerConfiguration.setFeePercentage(OUT_OF_RANGE_FEE_PERCENTAGE)
       ).to.be.revertedWith(VALUE_OUT_OF_PERCENT_RANGE_ERROR_MSG);

--- a/test/utils/constants.utils.ts
+++ b/test/utils/constants.utils.ts
@@ -1,6 +1,8 @@
 // ERRORS
 export const UN_NECESSARY_MODIFICATION_ERROR_MSG =
   'Param being modified is same as new param';
+export const VALUE_OUT_OF_PERCENT_RANGE_ERROR_MSG =
+  'Value must be within range 0 to 100';
 
 // EVENTS
 export const MIN_DURATION_CHANGED_EVENT = 'MinDurationChanged';

--- a/test/utils/constants.utils.ts
+++ b/test/utils/constants.utils.ts
@@ -2,7 +2,7 @@
 export const UN_NECESSARY_MODIFICATION_ERROR_MSG =
   'Param being modified is same as new param';
 export const VALUE_OUT_OF_PERCENT_RANGE_ERROR_MSG =
-  'Value must be within range 0 to 100';
+  'Value must be within range 0 to 100000000000000000000'; // 100000000000000000000 here is the precision representation of 100%
 
 // EVENTS
 export const MIN_DURATION_CHANGED_EVENT = 'MinDurationChanged';
@@ -27,6 +27,6 @@ export const DEFAULT_MAX_LENGTH = 7;
 export const DEFAULT_MIN_DURATION = 1;
 export const DEFAULT_MAX_DURATION = 2;
 export const DEFAULT_MIN_COMMITMENT_AGE = 0;
-export const DEFAULT_DISCOUNT = 4;
+export const DEFAULT_DISCOUNT = 0;
 export const DEFAULT_IS_UNICODE_SUPPORTED = false;
 export const DEFAULT_FEE_PERCENTAGE = 5;


### PR DESCRIPTION
This PR adds the support for applying the partner's discount in the pricing of new domain registrations and renewals.
Key highlights include:
- Gas cost savings by:
a: Not invoking token transfer methods when a 100% discount is applied
b: Only applying discount calculations when appropriate discount values are set.

- Validate input params for range appropriate values 

[JIRA TICKET HERE](https://rsklabs.atlassian.net/browse/RNS-242)