### PR TITLE
feat: simplified the partner adding operations

### DIFF
--- a/contracts/FeeManager/FeeManager.sol
+++ b/contracts/FeeManager/FeeManager.sol
@@ -94,7 +94,7 @@ contract FeeManager is IFeeManager {
         uint256 partnerFee = (amount *
             _getPartnerConfiguration(partner).getFeePercentage()) /
             _PERCENT100_WITH_PRECISION18;
-        _balances[_getPartnerOwnerAccount(partner)] += partnerFee;
+        _balances[partner] += partnerFee;
 
         uint256 balance = amount - partnerFee;
 
@@ -107,12 +107,6 @@ contract FeeManager is IFeeManager {
         address partner
     ) private view returns (IPartnerConfiguration) {
         return _partnerManager.getPartnerConfiguration(partner);
-    }
-
-    function _getPartnerOwnerAccount(
-        address partner
-    ) private view returns (address) {
-        return _partnerManager.getPartnerOwnerAccount(partner);
     }
 
     /**

--- a/contracts/PartnerManager/IPartnerManager.sol
+++ b/contracts/PartnerManager/IPartnerManager.sol
@@ -27,7 +27,7 @@ interface IPartnerManager {
         address indexed configurationContract
     );
     /**
-     * @notice event emitted when is removed from the whitelist
+     * @notice event emitted when a partner is removed from the whitelist
      * @param partner address for the partner
      */
     event PartnerRemoved(address indexed partner);
@@ -60,7 +60,8 @@ interface IPartnerManager {
     /**
      * @notice adds a partner to the whitelist and sets its configuration
      * @param partner address for the partner that will be whitelisted
-     * @param partnerConfiguration address of the contract in that implements the partner configuration
+     * @param partnerConfiguration address of the contract that implements the partner configuration interface
+     * @custom:emits-event emits the PartnerAdded event
      */
     function addPartner(
         address partner,
@@ -70,6 +71,7 @@ interface IPartnerManager {
     /**
      * @notice removes a partner from the whitelist
      * @param partner address for the partner that will be removed from the whitelist
+     * @custom:emits-event emits the PartnerRemoved event
      */
     function removePartner(address partner) external;
 }

--- a/contracts/PartnerManager/IPartnerManager.sol
+++ b/contracts/PartnerManager/IPartnerManager.sol
@@ -17,6 +17,20 @@ interface IPartnerManager {
         address partner,
         address configurationContract
     );
+    /**
+     * @notice event emitted when a partner is whitelisted and its configuration is set
+     * @param partner address for the partner
+     * @param configurationContract address of the configuration contract
+     */
+    event PartnerAdded(
+        address indexed partner,
+        address indexed configurationContract
+    );
+    /**
+     * @notice event emitted when is removed from the whitelist
+     * @param partner address for the partner
+     */
+    event PartnerRemoved(address indexed partner);
 
     /**
      * @notice sets the configuration for a partner
@@ -44,23 +58,18 @@ interface IPartnerManager {
     function isPartner(address partner) external view returns (bool);
 
     /**
-     * @notice adds a partner to the whitelist
+     * @notice adds a partner to the whitelist and sets its configuration
      * @param partner address for the partner that will be whitelisted
-     * @param partnerOwnerAccount address of the owner account for the partner that will be able to withdraw the collected funds
+     * @param partnerConfiguration address of the contract in that implements the partner configuration
      */
-    function addPartner(address partner, address partnerOwnerAccount) external;
+    function addPartner(
+        address partner,
+        IPartnerConfiguration partnerConfiguration
+    ) external;
 
     /**
      * @notice removes a partner from the whitelist
      * @param partner address for the partner that will be removed from the whitelist
      */
     function removePartner(address partner) external;
-
-    /**
-     * @notice returns the owner account of a partner
-     * @param partner address for the partner
-     */
-    function getPartnerOwnerAccount(
-        address partner
-    ) external view returns (address);
 }

--- a/contracts/PartnerManager/PartnerManager.sol
+++ b/contracts/PartnerManager/PartnerManager.sol
@@ -23,7 +23,7 @@ contract PartnerManager is IPartnerManager, HasAccessControl {
     /**
        @inheritdoc IPartnerManager
      */
-    function isPartner(address partner) public view override returns (bool) {
+    function isPartner(address partner) external view override returns (bool) {
         return _partners[partner].isPartner;
     }
 
@@ -68,7 +68,7 @@ contract PartnerManager is IPartnerManager, HasAccessControl {
             address(partnerConfiguration) != address(0),
             "PartnerManager: Invalid configuration"
         );
-        require(isPartner(partner), "PartnerManager: not a partner");
+        require(_partners[partner].isPartner, "PartnerManager: not a partner");
 
         _partners[partner].configuration = partnerConfiguration;
     }

--- a/contracts/PartnerManager/PartnerManager.sol
+++ b/contracts/PartnerManager/PartnerManager.sol
@@ -11,12 +11,12 @@ import "../Access/HasAccessControl.sol";
     @title Keeps track of the whitelisted partners and its configurations.
 */
 contract PartnerManager is IPartnerManager, HasAccessControl {
-    mapping(address => bool) private _partners;
-    mapping(address => IPartnerConfiguration) private _partnerConfigurations;
-    mapping(address => address) private _partnerOwnerAccounts;
+    struct Partner {
+        bool isPartner;
+        IPartnerConfiguration configuration;
+    }
 
-    event PartnerAdded(address indexed partner, address indexed ownerAccount);
-    event PartnerRemoved(address indexed partner, address indexed ownerAccount);
+    mapping(address => Partner) private _partners;
 
     constructor(IAccessControl accessControl) HasAccessControl(accessControl) {}
 
@@ -24,7 +24,7 @@ contract PartnerManager is IPartnerManager, HasAccessControl {
        @inheritdoc IPartnerManager
      */
     function isPartner(address partner) public view override returns (bool) {
-        return _partners[partner];
+        return _partners[partner].isPartner;
     }
 
     /**
@@ -32,11 +32,14 @@ contract PartnerManager is IPartnerManager, HasAccessControl {
      */
     function addPartner(
         address partner,
-        address partnerOwnerAccount
+        IPartnerConfiguration partnerConfiguration
     ) external override onlyHighLevelOperator {
-        _partners[partner] = true;
-        _partnerOwnerAccounts[partner] = partnerOwnerAccount;
-        emit PartnerAdded(partner, partnerOwnerAccount);
+        require(
+            !_partners[partner].isPartner,
+            "PartnerManager: Partner already exists"
+        );
+        _partners[partner] = Partner(true, partnerConfiguration);
+        emit PartnerAdded(partner, address(partnerConfiguration));
     }
 
     /**
@@ -45,9 +48,8 @@ contract PartnerManager is IPartnerManager, HasAccessControl {
     function removePartner(
         address partner
     ) external override onlyHighLevelOperator {
-        _partners[partner] = false;
-
-        emit PartnerRemoved(partner, _partnerOwnerAccounts[partner]);
+        emit PartnerRemoved(partner);
+        delete _partners[partner];
     }
 
     /**
@@ -57,25 +59,18 @@ contract PartnerManager is IPartnerManager, HasAccessControl {
         address partner,
         IPartnerConfiguration partnerConfiguration
     ) external override onlyHighLevelOperator {
-        if (
-            address(_partnerConfigurations[partner]) ==
-            address(partnerConfiguration)
-        ) {
-            revert("Param being modified is same as new param");
-        }
-
         emit PartnerConfigurationChanged(
             partner,
             address(partnerConfiguration)
         );
 
         require(
-            partnerConfiguration != IPartnerConfiguration(address(0)),
+            address(partnerConfiguration) != address(0),
             "PartnerManager: Invalid configuration"
         );
         require(isPartner(partner), "PartnerManager: not a partner");
 
-        _partnerConfigurations[partner] = partnerConfiguration;
+        _partners[partner].configuration = partnerConfiguration;
     }
 
     /**
@@ -84,24 +79,6 @@ contract PartnerManager is IPartnerManager, HasAccessControl {
     function getPartnerConfiguration(
         address partner
     ) public view override returns (IPartnerConfiguration) {
-        IPartnerConfiguration partnerConfiguration = _partnerConfigurations[
-            partner
-        ];
-
-        require(
-            address(partnerConfiguration) != address(0),
-            "Partner configuration not set"
-        );
-
-        return partnerConfiguration;
-    }
-
-    /**
-       @inheritdoc IPartnerManager
-     */
-    function getPartnerOwnerAccount(
-        address partner
-    ) external view override returns (address) {
-        return _partnerOwnerAccounts[partner];
+        return _partners[partner].configuration;
     }
 }

--- a/docs/PartnerManager.md
+++ b/docs/PartnerManager.md
@@ -1,31 +1,25 @@
 # PartnerManager
 
-*Identity Team @IOVLabs*
+_Identity Team @IOVLabs_
 
 > Keeps track of the whitelisted partners and its configurations.
-
-
-
-
 
 ## Methods
 
 ### addPartner
 
 ```solidity
-function addPartner(address partner, address partnerOwnerAccount) external nonpayable
+function addPartner(address partner, address configurationContract) external nonpayable
 ```
 
-adds a partner to the whitelist
-
-
+adds a partner to the whitelist and sets its configuration
 
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
-| partner | address | address for the partner that will be whitelisted |
-| partnerOwnerAccount | address | address of the owner account for the partner that will be able to withdraw the collected funds |
+| Name                 | Type    | Description                                                          |
+| -------------------- | ------- | -------------------------------------------------------------------- |
+| partner              | address | address for the partner that will be whitelisted                     |
+| partnerConfiguration | address | address of the contract in that implements the partner configuration |
 
 ### getPartnerConfiguration
 
@@ -35,19 +29,17 @@ function getPartnerConfiguration(address partner) external view returns (contrac
 
 returns the configuration for a partner
 
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
+| Name    | Type    | Description             |
+| ------- | ------- | ----------------------- |
 | partner | address | address for the partner |
 
 #### Returns
 
-| Name | Type | Description |
-|---|---|---|
-| _0 | contract IPartnerConfiguration | undefined |
+| Name | Type                           | Description |
+| ---- | ------------------------------ | ----------- |
+| \_0  | contract IPartnerConfiguration | undefined   |
 
 ### getPartnerOwnerAccount
 
@@ -57,19 +49,17 @@ function getPartnerOwnerAccount(address partner) external view returns (address)
 
 returns the owner account of a partner
 
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
+| Name    | Type    | Description             |
+| ------- | ------- | ----------------------- |
 | partner | address | address for the partner |
 
 #### Returns
 
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
+| Name | Type    | Description |
+| ---- | ------- | ----------- |
+| \_0  | address | undefined   |
 
 ### isPartner
 
@@ -79,19 +69,17 @@ function isPartner(address partner) external view returns (bool)
 
 returns true if the partner is whitelisted
 
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
+| Name    | Type    | Description             |
+| ------- | ------- | ----------------------- |
 | partner | address | address for the partner |
 
 #### Returns
 
 | Name | Type | Description |
-|---|---|---|
-| _0 | bool | undefined |
+| ---- | ---- | ----------- |
+| \_0  | bool | undefined   |
 
 ### owner
 
@@ -99,16 +87,13 @@ returns true if the partner is whitelisted
 function owner() external view returns (address)
 ```
 
-
-
-*Returns the address of the current owner.*
-
+_Returns the address of the current owner._
 
 #### Returns
 
-| Name | Type | Description |
-|---|---|---|
-| _0 | address | undefined |
+| Name | Type    | Description |
+| ---- | ------- | ----------- |
+| \_0  | address | undefined   |
 
 ### removePartner
 
@@ -118,12 +103,10 @@ function removePartner(address partner) external nonpayable
 
 removes a partner from the whitelist
 
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
+| Name    | Type    | Description                                                     |
+| ------- | ------- | --------------------------------------------------------------- |
 | partner | address | address for the partner that will be removed from the whitelist |
 
 ### renounceOwnership
@@ -132,10 +115,7 @@ removes a partner from the whitelist
 function renounceOwnership() external nonpayable
 ```
 
-
-
-*Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner.*
-
+_Leaves the contract without owner. It will not be possible to call `onlyOwner` functions anymore. Can only be called by the current owner. NOTE: Renouncing ownership will leave the contract without an owner, thereby removing any functionality that is only available to the owner._
 
 ### setPartnerConfiguration
 
@@ -145,14 +125,12 @@ function setPartnerConfiguration(address partner, contract IPartnerConfiguration
 
 sets the configuration for a partner
 
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
-| partner | address | address for the partner |
-| partnerConfiguration | contract IPartnerConfiguration | undefined |
+| Name                 | Type                           | Description             |
+| -------------------- | ------------------------------ | ----------------------- |
+| partner              | address                        | address for the partner |
+| partnerConfiguration | contract IPartnerConfiguration | undefined               |
 
 ### transferOwnership
 
@@ -160,17 +138,13 @@ sets the configuration for a partner
 function transferOwnership(address newOwner) external nonpayable
 ```
 
-
-
-*Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner.*
+_Transfers ownership of the contract to a new account (`newOwner`). Can only be called by the current owner._
 
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
-| newOwner | address | undefined |
-
-
+| Name     | Type    | Description |
+| -------- | ------- | ----------- |
+| newOwner | address | undefined   |
 
 ## Events
 
@@ -180,16 +154,12 @@ function transferOwnership(address newOwner) external nonpayable
 event OwnershipTransferred(address indexed previousOwner, address indexed newOwner)
 ```
 
-
-
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
-| previousOwner `indexed` | address | undefined |
-| newOwner `indexed` | address | undefined |
+| Name                    | Type    | Description |
+| ----------------------- | ------- | ----------- |
+| previousOwner `indexed` | address | undefined   |
+| newOwner `indexed`      | address | undefined   |
 
 ### PartnerAdded
 
@@ -197,16 +167,12 @@ event OwnershipTransferred(address indexed previousOwner, address indexed newOwn
 event PartnerAdded(address indexed partner, address indexed ownerAccount)
 ```
 
-
-
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
-| partner `indexed` | address | undefined |
-| ownerAccount `indexed` | address | undefined |
+| Name                   | Type    | Description |
+| ---------------------- | ------- | ----------- |
+| partner `indexed`      | address | undefined   |
+| ownerAccount `indexed` | address | undefined   |
 
 ### PartnerConfigurationChanged
 
@@ -216,14 +182,12 @@ event PartnerConfigurationChanged(address partner, address configurationContract
 
 event emitted when the configuration for a partner is set
 
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
-| partner  | address | undefined |
-| configurationContract  | address | undefined |
+| Name                  | Type    | Description |
+| --------------------- | ------- | ----------- |
+| partner               | address | undefined   |
+| configurationContract | address | undefined   |
 
 ### PartnerRemoved
 
@@ -231,16 +195,9 @@ event emitted when the configuration for a partner is set
 event PartnerRemoved(address indexed partner, address indexed ownerAccount)
 ```
 
-
-
-
-
 #### Parameters
 
-| Name | Type | Description |
-|---|---|---|
-| partner `indexed` | address | undefined |
-| ownerAccount `indexed` | address | undefined |
-
-
-
+| Name                   | Type    | Description |
+| ---------------------- | ------- | ----------- |
+| partner `indexed`      | address | undefined   |
+| ownerAccount `indexed` | address | undefined   |

--- a/docs/PartnerManager.md
+++ b/docs/PartnerManager.md
@@ -16,10 +16,10 @@ adds a partner to the whitelist and sets its configuration
 
 #### Parameters
 
-| Name                 | Type    | Description                                                          |
-| -------------------- | ------- | -------------------------------------------------------------------- |
-| partner              | address | address for the partner that will be whitelisted                     |
-| partnerConfiguration | address | address of the contract in that implements the partner configuration |
+| Name                 | Type    | Description                                                                 |
+| -------------------- | ------- | --------------------------------------------------------------------------- |
+| partner              | address | address for the partner that will be whitelisted                            |
+| partnerConfiguration | address | address of the contract that implements the partner configuration interface |
 
 ### getPartnerConfiguration
 

--- a/test/FeeManager.spec.ts
+++ b/test/FeeManager.spec.ts
@@ -94,10 +94,6 @@ describe('Fee Manager', () => {
           PartnerConfiguration.address
         );
 
-        PartnerManager.getPartnerOwnerAccount.returns(
-          partnerOwnerAccount.address
-        );
-
         await expect(
           feeManager.connect(registrar).deposit(partner.address, depositAmount)
         ).to.not.be.reverted;
@@ -167,9 +163,6 @@ describe('Fee Manager', () => {
         PartnerManager.getPartnerConfiguration.returns(
           PartnerConfiguration.address
         );
-        PartnerManager.getPartnerOwnerAccount.returns(
-          partnerOwnerAccount.address
-        );
 
         await expect(
           feeManager.connect(registrar).deposit(partner.address, depositAmount)
@@ -207,9 +200,6 @@ describe('Fee Manager', () => {
         PartnerManager.getPartnerConfiguration.returns(
           PartnerConfiguration.address
         );
-        PartnerManager.getPartnerOwnerAccount.returns(
-          partnerOwnerAccount.address
-        );
 
         await expect(
           feeManager.connect(registrar).deposit(partner.address, depositAmount)
@@ -231,7 +221,6 @@ describe('Fee Manager', () => {
     let feeManager: MockContract<FeeManagerType>,
       registrar: SignerWithAddress,
       partner: SignerWithAddress,
-      partnerOwnerAccount: SignerWithAddress,
       RIF: FakeContract<RIFType>,
       PartnerManager: FakeContract<PartnerManager>,
       PartnerConfiguration: FakeContract<PartnerConfiguration>;
@@ -244,7 +233,6 @@ describe('Fee Manager', () => {
       RIF = vars.RIF;
       PartnerConfiguration = vars.PartnerConfiguration;
       PartnerManager = vars.PartnerManager;
-      partnerOwnerAccount = vars.partnerOwnerAccount;
 
       const depositAmount = oneRBTC.mul(5);
       const feePercentage = oneRBTC.mul(5);
@@ -254,9 +242,6 @@ describe('Fee Manager', () => {
       PartnerManager.getPartnerConfiguration.returns(
         PartnerConfiguration.address
       );
-      PartnerManager.getPartnerOwnerAccount.returns(
-        partnerOwnerAccount.address
-      );
 
       await expect(
         feeManager.connect(registrar).deposit(partner.address, depositAmount)
@@ -265,11 +250,11 @@ describe('Fee Manager', () => {
 
     it('should withdraw successfully', async () => {
       try {
-        await expect(feeManager.connect(partnerOwnerAccount).withdraw()).to
-          .eventually.fulfilled;
-        expect(
-          await feeManager.getBalance(partnerOwnerAccount.address)
-        ).to.be.equals(ethers.constants.Zero);
+        await expect(feeManager.connect(partner).withdraw()).to.eventually
+          .fulfilled;
+        expect(await feeManager.getBalance(partner.address)).to.be.equals(
+          ethers.constants.Zero
+        );
       } catch (error) {
         console.log(error);
         throw error;
@@ -278,8 +263,8 @@ describe('Fee Manager', () => {
 
     it('should revert when user has no balance', async () => {
       try {
-        await expect(feeManager.connect(partnerOwnerAccount).withdraw()).to
-          .eventually.fulfilled;
+        await expect(feeManager.connect(partner).withdraw()).to.eventually
+          .fulfilled;
         await expect(
           feeManager.connect(partner).withdraw()
         ).to.be.revertedWithCustomError(feeManager, 'ZeroBalance');
@@ -292,14 +277,12 @@ describe('Fee Manager', () => {
     it('should revert if transfer fails', async () => {
       try {
         RIF.transfer.returns(false);
-        await expect(feeManager.connect(partnerOwnerAccount).withdraw())
+        await expect(feeManager.connect(partner).withdraw())
           .to.be.revertedWithCustomError(feeManager, 'TransferFailed')
           .withArgs(
             feeManager.address,
-            partnerOwnerAccount.address,
-            await feeManager
-              .connect(partnerOwnerAccount)
-              .getBalance(partnerOwnerAccount.address)
+            partner.address,
+            await feeManager.connect(partner).getBalance(partner.address)
           );
       } catch (error) {
         console.log(error);
@@ -329,10 +312,6 @@ describe('Fee Manager', () => {
         PartnerConfiguration.getFeePercentage.returns(feePercentage);
         PartnerManager.getPartnerConfiguration.returns(
           PartnerConfiguration.address
-        );
-
-        PartnerManager.getPartnerOwnerAccount.returns(
-          partnerOwnerAccount.address
         );
 
         await expect(
@@ -365,7 +344,6 @@ describe('Fee Manager', () => {
       PartnerManager.getPartnerConfiguration.returns(
         PartnerConfiguration.address
       );
-      PartnerManager.getPartnerOwnerAccount.returns(account3.address);
 
       await feeManager
         .connect(registrar)

--- a/test/PartnerManager.spec.ts
+++ b/test/PartnerManager.spec.ts
@@ -230,33 +230,6 @@ describe('partnerManager', () => {
         .withArgs(partner.address, account3.address);
     });
 
-    it('Should revert is the partner configuration to be set is same as existing', async () => {
-      const {
-        partnerManager,
-        account1: partner,
-        account3,
-        partnerOwnerAccount,
-      } = await loadFixture(testSetup);
-
-      await partnerManager.addPartner(
-        partner.address,
-        partnerOwnerAccount.address
-      );
-
-      await partnerManager.setPartnerConfiguration(
-        partner.address,
-        account3.address
-      );
-
-      // attempt to change partner configuration
-      await expect(
-        partnerManager.setPartnerConfiguration(
-          partner.address,
-          account3.address
-        )
-      ).to.be.revertedWith(UN_NECESSARY_MODIFICATION_ERROR_MSG);
-    });
-
     it('should revert if not partner address', async () => {
       const {
         partnerManager,

--- a/test/integration/PartnerRegistrar.spec.ts
+++ b/test/integration/PartnerRegistrar.spec.ts
@@ -23,7 +23,6 @@ describe('New Domain Registration (Integration)', () => {
       FeeManager,
       PartnerRegistrar,
       pool,
-      partnerOwnerAccount,
       partner,
     } = await loadFixture(initialSetup);
     const namePrice = await PartnerRegistrar.price(
@@ -70,7 +69,7 @@ describe('New Domain Registration (Integration)', () => {
     expect(+poolBalance).to.equal(+expectedPoolBalance);
 
     const partnerBalanceInFeeManager = await FeeManager.getBalance(
-      partnerOwnerAccount.address
+      partner.address
     );
     const expectedPartnerAccountBalance = expectedManagerBalance; //since it is the only operation...
     expect(+partnerBalanceInFeeManager).to.equal(
@@ -118,16 +117,6 @@ describe('New Domain Registration (Integration)', () => {
       NodeOwner,
       alternatePartnerConfiguration,
     } = await loadFixture(initialSetup);
-    await (
-      await PartnerManager.addPartner(partner.address, partner.address)
-    ).wait();
-
-    await (
-      await PartnerManager.setPartnerConfiguration(
-        partner.address,
-        alternatePartnerConfiguration.address
-      )
-    ).wait();
 
     RIF.transferFrom.returns(true);
     RIF.approve.returns(false);

--- a/test/integration/PartnerRenewer.spec.ts
+++ b/test/integration/PartnerRenewer.spec.ts
@@ -415,31 +415,16 @@ describe('Domain Renewal', () => {
   it('Should revert if token transfer approval fails', async () => {
     const {
       RIF,
-      FakeRIF,
       PartnerRenewer,
       PartnerRegistrar,
       nameOwner,
       partner,
-      PartnerManager,
       PartnerConfiguration,
       NodeOwner,
-      alternatePartnerConfiguration,
     } = await loadFixture(initialSetup);
 
-    await (
-      await PartnerManager.addPartner(partner.address, partner.address)
-    ).wait();
-
-    await (
-      await PartnerManager.setPartnerConfiguration(
-        partner.address,
-        alternatePartnerConfiguration.address
-      )
-    ).wait();
-
-    (await alternatePartnerConfiguration.setMinCommitmentAge(0)).wait();
-
     // First Register the name to be renewed
+    await (await PartnerConfiguration.setMinCommitmentAge(0)).wait();
 
     RIF.transferFrom.returns(true);
     RIF.approve.returns(true);
@@ -476,10 +461,6 @@ describe('Domain Renewal', () => {
       NodeOwner,
       alternatePartnerConfiguration,
     } = await loadFixture(initialSetup);
-
-    await (
-      await PartnerManager.addPartner(partner.address, partner.address)
-    ).wait();
 
     await (
       await PartnerManager.setPartnerConfiguration(
@@ -538,14 +519,9 @@ describe('Renewal events', () => {
       nameOwner,
       partner,
       PartnerManager,
-      PartnerConfiguration,
       NodeOwner,
       alternatePartnerConfiguration,
     } = await loadFixture(initialSetup);
-
-    await (
-      await PartnerManager.addPartner(partner.address, partner.address)
-    ).wait();
 
     await (
       await PartnerManager.setPartnerConfiguration(

--- a/test/integration/utils/initialSetup.ts
+++ b/test/integration/utils/initialSetup.ts
@@ -21,7 +21,6 @@ export const initialSetup = async () => {
   const signers = await ethers.getSigners();
   const owner = signers[0];
   const partner = signers[1];
-  const partnerOwnerAccount = signers[2];
   const nameOwner = signers[3];
   const pool = signers[4];
   const regularUser = signers[5];
@@ -147,12 +146,6 @@ export const initialSetup = async () => {
   await (
     await PartnerManager.addPartner(
       partner.address,
-      partnerOwnerAccount.address
-    )
-  ).wait();
-  await (
-    await PartnerManager.setPartnerConfiguration(
-      partner.address,
       PartnerConfiguration.address
     )
   ).wait();
@@ -187,7 +180,6 @@ export const initialSetup = async () => {
     Resolver,
     RNS,
     owner,
-    partnerOwnerAccount,
     nameOwner,
     signers,
     pool,


### PR DESCRIPTION
Simplified the addPartner function in the PartnerManager. Since the partner Proxy stuff got removed, having a different address to identify the partner account doesnt make sense anymore. 
Also added the ability to set the configuration of the partner in the same step. 