### PR TITLE
fix: include partner address to deployed addresses json

### DIFF
--- a/scripts/local-deploy.ts
+++ b/scripts/local-deploy.ts
@@ -290,6 +290,7 @@ async function main() {
       feeManager: FeeManager.address,
       defaultPartnerConfiguration: DefaultPartnerConfiguration.address,
       registrarAccessControl: RegistrarAccessControlContract.address,
+      partner: partner.address,
     };
 
     fs.writeFileSync(


### PR DESCRIPTION
This tiny fix is just to include the partner address to the deployed addresses json file as it is needed for the manager to work with the new contract changes