### PR TITLE
Fix broken integration test utility

### DIFF
--- a/scripts/testnet-deploy.ts
+++ b/scripts/testnet-deploy.ts
@@ -29,7 +29,7 @@ const tldNode = namehash('rsk');
 const tldAsSha3 = utils.id('rsk');
 const reverseTldAsSha3 = utils.id('reverse');
 const FEE_PERCENTAGE = oneRBTC.mul(0); //0%
-const POOL_ADDRESS = '0xcd32d5b7c2e1790029d3106d9f8347f42a3dfd60' // multisig testnet address
+const POOL_ADDRESS = '0xcd32d5b7c2e1790029d3106d9f8347f42a3dfd60'; // multisig testnet address
 
 // TODO: define tRIF address
 const tRIF_ADDRESS =

--- a/test/integration/utils/operations.ts
+++ b/test/integration/utils/operations.ts
@@ -332,7 +332,9 @@ export const generateRandomStringWithLettersAndNumbers = (
     }
   }
 
-  //
+  if (domainName.length > length) {
+    domainName = domainName.substring(0, length);
+  }
 
   if (length == 0) return '';
   else return domainName;


### PR DESCRIPTION
This PR fixes a bug with an integration test utility function `generateRandomStringWithLettersAndNumbers` that causes this function to generate a string with length greater than specified when numbers are included