### PR TITLE
chore: use correct values for percentage constants

### DIFF
--- a/scripts/local-deploy.ts
+++ b/scripts/local-deploy.ts
@@ -29,11 +29,11 @@ const rootNodeId = ethers.constants.HashZero;
 const tldNode = namehash('rsk');
 const tldAsSha3 = utils.id('rsk');
 const reverseTldAsSha3 = utils.id('reverse');
-const ZERO_FEE_PERCENTAGE = oneRBTC.mul(0); //0%
-const HALF_FEE_PERCENTAGE = oneRBTC.mul(50); //50%
-const HALF_DISCOUNT_PERCENTAGE = oneRBTC.mul(50); //50%
-const FIVE_PERCENTAGE = ethers.utils.parseEther('0.05'); //5%
-const TEN_PERCENTAGE = ethers.utils.parseEther('0.1'); //10%
+const ZERO_FEE_PERCENTAGE = ethers.utils.parseEther('0'); //0%
+const HALF_FEE_PERCENTAGE = ethers.utils.parseEther('50'); //50%
+const HALF_DISCOUNT_PERCENTAGE = ethers.utils.parseEther('50'); //50%
+const FIVE_PERCENTAGE = ethers.utils.parseEther('5'); //5%
+const TEN_PERCENTAGE = ethers.utils.parseEther('10'); //10%
 
 async function main() {
   try {

--- a/scripts/testnet-deploy.ts
+++ b/scripts/testnet-deploy.ts
@@ -21,8 +21,8 @@ const tldNode = namehash('rsk');
 const tldAsSha3 = utils.id('rsk');
 const reverseTldAsSha3 = utils.id('reverse');
 const ZERO_PERCENTAGE = oneRBTC.mul(0); // 0%
-const FIVE_PERCENTAGE = ethers.utils.parseEther('0.05'); // 5%
-const TEN_PERCENTAGE = ethers.utils.parseEther('0.1'); // 10%
+const FIVE_PERCENTAGE = ethers.utils.parseEther('5'); //5%
+const TEN_PERCENTAGE = ethers.utils.parseEther('10'); //10%
 const POOL_ADDRESS = '0xcd32d5b7c2e1790029d3106d9f8347f42a3dfd60'; // multisig testnet address
 
 // Addresses deployed on testnet: https://dev.rootstock.io/rif/rns/testnet/


### PR DESCRIPTION
This PR uses the correct implementation for percentage constants on the deploy scripts
